### PR TITLE
Etcd lock strategy causes invalid %p error on bastion during reboot.  Manually control reboot strategy.

### DIFF
--- a/src/bartnet/launch.clj
+++ b/src/bartnet/launch.clj
@@ -84,7 +84,7 @@
                                :DNS_SERVER (:dns-server bastion-config)
                                :NSQD_HOST (:nsqd-host bastion-config)})}]
      :coreos {:update
-              {:reboot-strategy "etcd-lock"
+              {:reboot-strategy "off"
                :group "beta"}}})))
 
 (defn parse-cloudformation-msg [instance-id msg]


### PR DESCRIPTION
@cliff, thoughts on this?  https://trello.com/c/o6qGsg7a/413-bastion-sometimes-etcd-restarts-due-to-update  Perhaps we could allow the user to update by restarting the bastion.
