### PR TITLE
the ability to specify subnet id when launching in a vpc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pom.xml.asc
 *.sublime-workspace
 src/co/opsee/proto/*
 schema.sql
+bartnetenv

--- a/config.json
+++ b/config.json
@@ -17,18 +17,34 @@
     {
         "port":8080
     },
-    "bastion-server":
-    {
-        "port":4080
-    },
     "ami":{
         "owner-id":"933693344490",
         "tag":"stable",
         "keypair":"bastion-testing",
         "template-src":{"resource":"bastion-cf.template"}
     },
-    "mailgun":{
-        "api_key":"key-d45f90c5a3e2ac33a26cd4c30715b71b",
-        "url":"https://api.mailgun.net/v3/mg.opsee.co"
+    "bastion": {
+      "vpn-remote": "{{BASTION_VPN_REMOTE}}",
+      "dns-server": "{{BASTION_DNS}}",
+      "nsqd-host": "{{NSQ_PRODUCE_HOST}}:{{NSQ_PRODUCE_PORT}}"
+    },
+    "nsq": {
+      "lookup": {
+        "host": "{{NSQ_LOOKUP_HOST}}",
+        "port": {{NSQ_LOOKUP_PORT}}
+      },
+      "produce": {
+        "host": "{{NSQ_PRODUCE_HOST}}",
+        "port": {{NSQ_PRODUCE_PORT}}
+      }
+    },
+    "fieri": {
+      "addr": "{{FIERI_ADDR}}"
+    },
+    "vape": {
+      "addr": "{{VAPE_ADDR}}"
+    },
+    "beavis":{
+      "addr": "{{BEAVIS_ADDR}}"
     }
 }

--- a/resources/bastion-cf.template
+++ b/resources/bastion-cf.template
@@ -26,12 +26,23 @@
             "Description" : "The VPC in which to deploy the instance",
             "Type": "String",
             "ConstraintDescription" : "Must be a valid VPC ID"
+        },
+        "SubnetId" : {
+            "Description" : "The subnet in which to deploy the instance (optional)",
+            "Default": "",
+            "Type": "String"
         }
     },
     "Conditions": {
         "NoKey": {
             "Fn::Equals": [
                 {"Ref": "KeyName"},
+                ""
+            ]
+        },
+        "NoSubnet": {
+            "Fn::Equals": [
+                {"Ref": "SubnetId"},
                 ""
             ]
         }
@@ -166,6 +177,13 @@
                         "NoKey",
                         {"Ref": "AWS::NoValue"},
                         {"Ref":"KeyName"}
+                    ]
+                },
+                "SubnetId": {
+                    "Fn::If": [
+                        "NoSubnet",
+                        {"Ref": "AWS::NoValue"},
+                        {"Ref":"SubnetId"}
                     ]
                 },
                 "SecurityGroupIds": [{"Ref": "BastionSecurityGroup"}],

--- a/test/bartnet/t_api.clj
+++ b/test/bartnet/t_api.clj
@@ -245,7 +245,27 @@
                      amazonica.aws.ec2/describe-instances (fn [creds & args]
                                                             (case (:endpoint creds)
                                                               "us-west-1" (:us-west-1 fixtures)
-                                                              "us-west-2" (:us-west-2 fixtures)))]
+                                                              "us-west-2" (:us-west-2 fixtures)))
+                     amazonica.aws.ec2/describe-subnets (fn [creds]
+                                                          (case (:endpoint creds)
+                                                            "us-west-1" {:subnets
+                                                                         [{:tags []
+                                                                           :subnet-id "subnet-abcd1111"
+                                                                           :default-for-az true
+                                                                           :state "available"
+                                                                           :vpc-id "vpc-79b1491c"
+                                                                           :map-public-ip-on-launch true
+                                                                           :available-ip-address-count 124
+                                                                           :cidr-block "172.31.0.0/24"}]}
+                                                            "us-west-2" {:subnets
+                                                                         [{:tags []
+                                                                           :subnet-id "subnet-zyxw2222"
+                                                                           :default-for-az true
+                                                                           :state "available"
+                                                                           :vpc-id "vpc-82828282"
+                                                                           :map-public-ip-on-launch true
+                                                                           :available-ip-address-count 124
+                                                                           :cidr-block "172.31.0.0/24"}]}))]
          (fact "aws api's get called for every region"
                (let [response ((app) (-> (mock/request :post "/scan-vpcs" (generate-string {:access-key "SDFSDFDSF"
                                                                                             :secret-key "sdfsdf+sasdasdasdsdfsdf"
@@ -255,11 +275,15 @@
                  (:body response) => (is-json (just [(contains {:region "us-west-1"
                                                                 :ec2-classic false
                                                                 :vpcs (just [(contains {:vpc-id "vpc-79b1491c"
-                                                                                        :count 1})])})
+                                                                                        :count 1
+                                                                                        :subnets (just [(contains {:subnet-id "subnet-abcd1111"
+                                                                                                                   :vpc-id "vpc-79b1491c"})])})])})
                                                      (contains {:region "us-west-2"
                                                                 :ec2-classic true
                                                                 :vpcs (just [(contains {:vpc-id "vpc-82828282"
-                                                                                        :count 1})])})]))))))
+                                                                                        :count 1
+                                                                                        :subnets (just [(contains {:subnet-id "subnet-zyxw2222"
+                                                                                                                   :vpc-id "vpc-82828282"})])})])})]))))))
 (facts "instance store"
   (with-redefs [clj-http.client/get (mock-get {"/groups/security" {:status 200 :body (:groups fixtures)}
                                                "/group/security/sg-c852dbad" {:status 200 :body (:group fixtures)}


### PR DESCRIPTION
/scan-vpcs will now return a subnets key for each vpc. We should then send a subnet_id along in the launch bastions command.
