### PR TITLE
Add support for rebooting instances

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -68,7 +68,7 @@
                  [de.ubercode.clostache/clostache "1.4.0"]
                  [instaparse "1.4.0"]
                  [org.clojure/core.match "0.3.0-alpha4"]
-                 [co.opsee/opsee-middleware "0.1.11"]
+                 [co.opsee/opsee-middleware "0.1.13"]
                  [manifold "0.1.0"]
                  [clj-disco "0.0.1"]
                  [org.bitbucket.b_c/jose4j "0.4.4"]])

--- a/src/bartnet/aws_rpc.clj
+++ b/src/bartnet/aws_rpc.clj
@@ -1,0 +1,50 @@
+(ns bartnet.aws-rpc
+  (:require [bartnet.bastion-router :as router]
+            [clojure.tools.logging :as log])
+  (:import (io.grpc.transport.netty NettyChannelBuilder NegotiationType)
+           (co.opsee.proto ec2Grpc ec2Grpc$ec2BlockingClient)
+           (io.grpc ChannelImpl)))
+
+(defprotocol ec2Client
+  (shutdown [this])
+  (start-instances [this req])
+  (stop-instances [this req])
+  (reboot-instances [this req]))
+
+(defrecord Realec2Client [^ChannelImpl channel ^ec2Grpc$ec2BlockingClient stub]
+  ec2Client
+  (start-instances [_ req]
+    (log/info "start instances" req)
+    (let [resp (.startInstances stub req)]
+      (log/info "resp" resp)
+      resp))
+
+  (stop-instances [_ req]
+    (log/info "stop instances" req)
+    (let [resp (.stopInstances stub req)]
+      (log/info "resp" resp)
+      resp))
+
+  (reboot-instances [_ req]
+    (log/info "reboot instances" req)
+    (let [resp (.rebootInstances stub req)]
+      (log/info "resp" resp)
+      resp))
+
+  (shutdown [_]
+    (.shutdown channel)))
+
+(defn ec2-client [{:keys [host port]}]
+  (let [channel (->
+                 (NettyChannelBuilder/forAddress host port)
+                 (.negotiationType NegotiationType/PLAINTEXT)
+                 .build)
+        stub (ec2Grpc/newBlockingStub channel)]
+    (->Realec2Client channel stub)))
+
+(defn specific-bastion [customer-id action host port]
+  (let [client (ec2-client {:host host :port port})]
+         (try
+           (action client)
+           (catch Exception ex (log/warn ex "Error talking to bastion "))
+           (finally (shutdown client)))))

--- a/websocket_test.html
+++ b/websocket_test.html
@@ -8,6 +8,7 @@
 			var wsUri = "ws://" + host + "/stream/";
 			var launchUri = "http://" + host + "/bastions/launch";
 			var checkUri = "http://" + host + "/bastions";
+			var awsUri = "http://" + host + "/aws";
             var bearer = ""
             var basic = {email:'', customer_id:'', id:'', admin:true}
             
@@ -21,13 +22,44 @@
 				//startWebsocket();
 			}
 
+            function startInstance() {
+				var req = new XMLHttpRequest();
+				req.open("POST", awsUri + "/start-instances", true);
+				req.setRequestHeader("Content-Type", "application/json");
+				req.setRequestHeader("Authorization", "Basic " + basic_token);
+				req.send(JSON.stringify({
+                    "dryRun": false,
+					"InstanceIds": ["i-53bcc6e1"]
+				}));
+			}
+	
+			function stopInstance() {
+				var req = new XMLHttpRequest();
+				req.open("POST", awsUri + "/stop-instances", true);
+				req.setRequestHeader("Content-Type", "application/json");
+				req.setRequestHeader("Authorization", "Basic " + basic_token);
+				req.send(JSON.stringify({
+                    "dryRun": false,
+					"InstanceIds": ["i-53bcc6e1"]
+				}));
+			}
+			function rebootInstance() {
+				var req = new XMLHttpRequest();
+				req.open("POST", awsUri + "/reboot-instances", true);
+				req.setRequestHeader("Content-Type", "application/json");
+				req.setRequestHeader("Authorization", "Basic " + basic_token);
+				req.send(JSON.stringify({
+                    "dryRun": false,
+					"InstanceIds": ["i-53bcc6e1"]
+				}));
+			}
+
 			function startLaunch() {
 				var req = new XMLHttpRequest();
 				req.open("POST", launchUri, true);
 				req.setRequestHeader("Content-Type", "application/json");
 				req.setRequestHeader("Authorization", "Basic " + basic_token);
 				req.send(JSON.stringify({
-					"access-key": "",
 					"secret-key": "",
 					"regions": [
 						{
@@ -40,7 +72,6 @@
 					"instance-size": "t2.micro"
 				}));
 			}
-
 			function startWebsocket() {
 				var websocket = new WebSocket(wsUri);
 				websocket.onopen = function(evt) {
@@ -87,6 +118,9 @@
 	</head>
 	<body>
 	<button label="launch bastion" onclick="startLaunch();">launch bastion</button>
+	<button label="launch bastion" onclick="rebootInstance();">reboot instance</button>
+	<button label="launch bastion" onclick="stopInstance();">stop instance</button>
+	<button label="launch bastion" onclick="startInstance();">start instance</button>
 	<div id="output">
 
 	</div>


### PR DESCRIPTION
- Added support for ec2.RebootInstances(...), ec2.StopInstances(..), ec2.StartInstances(..) via aws_rpc.clj
- Added support for and tested ec2.RebootInstances in api.clj

So, I still need to add in support for StartInstances and StopInstances in api.clj
