### PR TITLE
add targets to checks table and objects

### DIFF
--- a/resources/migrations.xml
+++ b/resources/migrations.xml
@@ -385,5 +385,18 @@
     <sql>
       alter table assertions alter column operand drop not null;
     </sql>
-  </changeSet>
+</changeSet>
+<changeSet id="28" author="mike" runInTransaction="true" failOnError="true">
+    <sql>
+        alter table checks add column target_name varchar(255);
+        alter table checks add column target_type varchar(255);
+        update checks c set target_name = t.name from targets t where c.target_id = t.id;
+        update checks c set target_type = t.type from targets t where c.target_id = t.id;
+        alter table checks drop constraint fk_checks_targets;
+        drop table targets;
+        alter table checks alter COLUMN target_id set not null;
+        alter table checks alter COLUMN target_type set not null;
+        alter table checks drop column last_run;
+    </sql>
+</changeSet>
 </databaseChangeLog>

--- a/src/bartnet/api.clj
+++ b/src/bartnet/api.clj
@@ -108,18 +108,14 @@
         instance-ids (router/get-customer-bastions (:customer_id login))]
     {:bastions (reduce conj [] instance-ids)}))
 
-(defn ensure-target-created [target]
-  (if (empty? (sql/get-target-by-id @db (:id target)))
-    (sql/insert-into-targets! @db target))
-  (:id target))
-
-(defn retrieve-target [target-id]
-  (first (sql/get-target-by-id @db target-id)))
-
 (defn resolve-target [check]
-  (if (:target check)
-    (assoc check :target_id (ensure-target-created (:target check)))
-    (dissoc (assoc check :target (retrieve-target (:target_id check))) :target_id)))
+  (if-let [target (:target check)]
+    (assoc check :target_id (:id target) :target_name (:name target) :target_type (:type target))
+    (dissoc (assoc check :target {
+                                  :id (:target_id check)
+                                  :name (:target_name check)
+                                  :type (:target_type check)})
+            :target_id :target_name :target_type)))
 
 (defn resolve-lastrun [check customer-id]
   (try

--- a/src/queries.sql
+++ b/src/queries.sql
@@ -1,26 +1,17 @@
--- name: insert-into-targets!
--- Inserts a new record into the targets table.
-insert into targets (id, type, name) values (:id, :type, :name);
-
--- name: get-target-by-id
--- Retrieves a target by its id.
-select * from targets where id=:id;
-
------------------------------------------------------------------------------
-
 -- name: insert-into-checks!
 -- Inserts a new record into the checks table.
-insert into checks (id, name, customer_id, "interval", target_id, last_run, check_spec) values
-                  (:id, :name, :customer_id::UUID, :interval, :target_id, :last_run, :check_spec::jsonb);
+insert into checks (id, name, customer_id, "interval", target_id, check_spec, target_name, target_type) values
+                  (:id, :name, :customer_id::UUID, :interval, :target_id, :check_spec::jsonb, :target_name, :target_type);
 
 -- name: update-check!
 -- Updates an existing health_check record.
 update checks set customer_id = :customer_id::UUID,
                   "interval" = :interval,
                   target_id = :target_id,
-                  last_run = :last_run,
                   name = :name,
-                  check_spec = :check_spec where id=:id;
+                  check_spec = :check_spec,
+                  target_name = :target_name,
+                  target_type = :target_type where id=:id;
 
 -- name: get-check-by-id
 -- Retrieves a health check record.

--- a/test/bartnet/fixtures.clj
+++ b/test/bartnet/fixtures.clj
@@ -13,31 +13,53 @@
            (java.util.regex Pattern)
            (clojure.lang PersistentArrayMap PersistentVector Seqable IPersistentMap)))
 
-(defn target-fixtures [db]
-  (do
-    (sql/insert-into-targets! db {:id   "sg-123"
-                                  :type "sg"
-                                  :name "coreos"})))
-
 (defn check-fixtures [db]
   (do
-    (sql/insert-into-targets! db {:id   "sg-123"
-                                  :name "boreos"
-                                  :type "sg"})
     (sql/insert-into-checks! db {:id             "check1"
                                  :name           "boreos"
                                  :customer_id    "154ba57a-5188-11e5-8067-9b5f2d96dce1"
                                  :target_id      "sg-123"
+                                 :target_type    "sg"
+                                 :target_name    "boreos"
                                  :interval       60
-                                 :last_run       (-> (Timestamp/newBuilder)
-                                                     (.setSeconds 1440802961)
-                                                     .build)
                                  :check_spec     {:type_url "HttpCheck"
                                                   :value {:name "A Good Check"
                                                           :path "/health_check"
                                                           :port 80
                                                           :verb "GET"
                                                           :protocol "http"}}})))
+
+(defn check-fixtures-2 [db]
+  (do
+    (sql/insert-into-checks! db {:id             "check1"
+                                 :name           "my-service elb"
+                                 :customer_id    "375f5afc-1880-11e6-a61e-6fdd17fa0f56"
+                                 :target_id      "my-service"
+                                 :interval       60
+                                 :target_type    "elb"
+                                 :target_name    "my-service"
+                                 :check_spec     {:type_url "HttpCheck"
+                                                  :value {:name "elb check"
+                                                          :path "/health"
+                                                          :port 9092
+                                                          :verb "GET"}}})
+    (sql/insert-into-checks! db {:id             "check2"
+                                 :name           "my-serice rds"
+                                 :customer_id    "375f5afc-1880-11e6-a61e-6fdd17fa0f56"
+                                 :target_id      "my-service"
+                                 :interval       60
+                                 :target_name    "my-service"
+                                 :target_type    "dbinstance"
+                                 :check_spec     {:type_url "CloudWatchCheck"
+                                                  :value {:metrics (vector
+                                                                     {:name  "CPUUtilization"
+                                                                      :namespace "AWS/RDS"}
+                                                                     {:name "DatabaseConnections"
+                                                                      :namespace "AWS/RDS"}
+                                                                     {:name "FreeStorageSpace"
+                                                                      :namespace "AWS/RDS"}
+                                                                     )}}})))
+
 
 (defn assertions-fixtures [db]
       (sql/insert-into-assertions! db {:check_id "check1"
@@ -49,6 +71,22 @@
                                        })
       (sql/insert-into-assertions! db {:check_id "check1"
                                        :customer_id "154ba57a-5188-11e5-8067-9b5f2d96dce1"
+                                       :key "header"
+                                       :value "accept-encoding"
+                                       :relationship "equal"
+                                       :operand "gzip"
+                                       }))
+
+(defn assertions-fixtures-2 [db]
+      (sql/insert-into-assertions! db {:check_id "check1"
+                                       :customer_id "375f5afc-1880-11e6-a61e-6fdd17fa0f56"
+                                       :key "body"
+                                       :value ""
+                                       :relationship "equal"
+                                       :operand "foo"
+                                       })
+      (sql/insert-into-assertions! db {:check_id "check1"
+                                       :customer_id "375f5afc-1880-11e6-a61e-6fdd17fa0f56"
                                        :key "header"
                                        :value "accept-encoding"
                                        :relationship "equal"

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -487,6 +487,7 @@
       "customer_id":"154ba57a-5188-11e5-8067-9b5f2d96dce1"
     }
   ],
+  "customer-query-2":[],
   "group-query":[
     {
       "check_id":"check2",


### PR DESCRIPTION
fix issue with targets of diff types w/same name and associate a single target with every check.  the migration here drops the targets table after adding all to new cols in checks table.
